### PR TITLE
Following the Scheduler workshop

### DIFF
--- a/python/lsst/ts/scheduler/conf/__init__.py
+++ b/python/lsst/ts/scheduler/conf/__init__.py
@@ -1,0 +1,1 @@
+from .conf_utils import *

--- a/python/lsst/ts/scheduler/conf/conf_utils.py
+++ b/python/lsst/ts/scheduler/conf/conf_utils.py
@@ -1,0 +1,27 @@
+import os
+
+
+def load_override_configuration(config, path):
+    """A utility method to load the pexConfig override configuration given a path.
+
+    Parameters
+    ----------
+    config
+    path
+
+    Returns
+    -------
+
+    """
+    config_files = os.listdir(path)
+
+    for ifile in config_files:
+        try:
+            load_file = os.path.join(path, ifile)
+            if not os.path.isdir(load_file):
+                config.load(load_file)
+        except AssertionError:
+            # Not the right configuration file, so do nothing.
+            pass
+
+

--- a/python/lsst/ts/scheduler/driver.py
+++ b/python/lsst/ts/scheduler/driver.py
@@ -17,27 +17,7 @@ class DriverParameters(pexConfig.Config):
     it is possible to subclass this and add the required parameters (e.g. file paths or else). Then, replace
     self.params on the Driver by the subclassed configuration.
     """
-    night_boundary = pexConfig.Field('Solar altitude (degrees) when it is considered night.', float)
-    new_moon_phase_threshold = pexConfig.Field('New moon phase threshold for swapping to dark time filter.',
-                                               float)
-    startup_type = pexConfig.ChoiceField("The method used to startup the scheduler.", str,
-                                         default='HOT',
-                                         allowed={"HOT": "Hot start, this means the scheduler is started up from "
-                                                         "scratch",
-                                                  "WARM": "Reads the scheduler state from a previously saved "
-                                                          "internal state.",
-                                                  "COLD": "Rebuilds scheduler state from observation database.", })
-    startup_database = pexConfig.Field("Path to the file holding scheduler state or observation database "
-                                       "to be used on WARM or COLD start.", str, default='')
-
-    def setDefaults(self):
-        """Set defaults for the LSST Scheduler's Driver.
-        """
-        self.night_boundary = -12.0
-        self.new_moon_phase_threshold = 20.0
-        self.startup_type = 'HOT'
-        self.startup_database = ''
-
+    pass
 
 class Driver(object):
     def __init__(self, models, raw_telemetry, params=None):

--- a/python/lsst/ts/scheduler/driver.py
+++ b/python/lsst/ts/scheduler/driver.py
@@ -1,283 +1,83 @@
 from builtins import object
 import logging
 
-from lsst.ts.astrosky.model import AstronomicalSkyModel
-from lsst.ts.dateloc import ObservatoryLocation
-from lsst.ts.observatory.model import ObservatoryModel
-from lsst.ts.observatory.model import ObservatoryState
+from lsst.ts.scheduler.kernel import SurveyTopology
+
 from lsst.ts.observatory.model import Target
-from lsst.ts.scheduler.setup import WORDY
+
+import lsst.pex.config as pexConfig
 
 __all__ = ["Driver", "DriverParameters"]
 
 
-class DriverParameters(object):
+class DriverParameters(pexConfig.Config):
+    """Actual global driver configuration parameters.
 
-    def __init__(self):
-        self.night_boundary = 0.0
-        self.new_moon_phase_threshold = 0.0
-        self.startup_type = ''
+    This can be expanded for other scheduler drivers. For instance, if your scheduler uses a certain configuration file
+    it is possible to subclass this and add the required parameters (e.g. file paths or else). Then, replace
+    self.params on the Driver by the subclassed configuration.
+    """
+    night_boundary = pexConfig.Field('Solar altitude (degrees) when it is considered night.', float)
+    new_moon_phase_threshold = pexConfig.Field('New moon phase threshold for swapping to dark time filter.',
+                                               float)
+    startup_type = pexConfig.ChoiceField("The method used to startup the scheduler.", str,
+                                         default='HOT',
+                                         allowed={"HOT": "Hot start, this means the scheduler is started up from "
+                                                         "scratch",
+                                                  "WARM": "Reads the scheduler state from a previously saved "
+                                                          "internal state.",
+                                                  "COLD": "Rebuilds scheduler state from observation database.", })
+    startup_database = pexConfig.Field("Path to the file holding scheduler state or observation database "
+                                       "to be used on WARM or COLD start.", str, default='')
+
+    def setDefaults(self):
+        """Set defaults for the LSST Scheduler's Driver.
+        """
+        self.night_boundary = -12.0
+        self.new_moon_phase_threshold = 20.0
+        self.startup_type = 'HOT'
         self.startup_database = ''
-
-    def configure(self, confdict):
-        self.night_boundary = confdict["constraints"]["night_boundary"]
-        self.new_moon_phase_threshold = confdict["darktime"]["new_moon_phase_threshold"]
-        self.startup_type = confdict["startup"]["type"]
-        self.startup_database = confdict["startup"]["database"]
 
 
 class Driver(object):
-    def __init__(self):
+    def __init__(self, models, raw_telemetry, params=None):
+        """Initialize base scheduler driver.
+
+        Parameters
+        ----------
+        models: A dictionary with models available for the scheduling algorithm.
+        raw_telemetry: A dictionary with available raw telemetry.
+        """
         self.log = logging.getLogger("schedulerDriver")
 
-        self.params = DriverParameters()
-        self.location = ObservatoryLocation()
+        if params is None:
+            self.params = DriverParameters()
+        else:
+            self.params = params
+        self.models = models
+        self.raw_telemetry = raw_telemetry
 
-        self.observatoryModel = ObservatoryModel(self.location, WORDY)
-        self.observatoryModel2 = ObservatoryModel(self.location, WORDY)
-        self.observatoryState = ObservatoryState()
-
-        self.sky = AstronomicalSkyModel(self.location)
-
-        self.propid_counter = 0
-        self.night = 0
-        self.start_time = 0.0
-        self.time = 0.0
-        self.targetid = 0
-        self.survey_started = False
-        self.isnight = False
-        self.sunset_timestamp = 0.0
-        self.sunrise_timestamp = 0.0
-        self.survey_duration_DAYS = 0.0
-        self.survey_duration_SECS = self.survey_duration_DAYS * 24 * 60 * 60.0
-        self.darktime = False
-        self.mounted_filter = ""
-        self.unmounted_filter = ""
-        self.midnight_moonphase = 0.0
-
-        self.nulltarget = Target()
-        self.nulltarget.targetid = -1
-        self.nulltarget.num_exp = 1
-        self.nulltarget.exp_times = [0.0]
-        self.nulltarget.num_props = 1
-        self.nulltarget.propid_list = [0]
-        self.nulltarget.need_list = [0.0]
-        self.nulltarget.bonus_list = [0.0]
-        self.nulltarget.value_list = [0.0]
-        self.nulltarget.propboost_list = [1.0]
-
-        self.last_winner_target = self.nulltarget.get_copy()
-        self.deep_drilling_target = None
-
-        self.need_filter_swap = False
-        self.filter_to_unmount = ""
-        self.filter_to_mount = ""
-
-        self.cloud = 0.0
-        self.seeing = 0.0
-
-    def configure_scheduler(self, **kwargs):
-        raise NotImplemented
-
-    def configure_duration(self, survey_duration):
-
-        self.survey_duration_DAYS = survey_duration
-        self.survey_duration_SECS = survey_duration * 24 * 60 * 60.0
-
-    def configure(self, confdict):
-        self.params.configure(confdict)
-        self.log.log(WORDY,
-                     "configure: night_boundary=%.1f" % (self.params.night_boundary))
-
-    def configure_location(self, confdict):
-
-        self.location.configure(confdict)
-        self.observatoryModel.location.configure(confdict)
-        self.observatoryModel2.location.configure(confdict)
-        self.sky.update_location(self.location)
-
-    def configure_observatory(self, confdict):
-        """This method calls the configure()method in ObservatoryModel class,
-        which configures all its submodules. When initializing one can issue
-        a call to this method with a complete set of parameters on confdict.
+    def configure_scheduler(self):
+        """
 
         Parameters
         ----------
-        confdict : dict()
+        config_name : The name of the file with the scheduler configuration.
+        config_path : The path to the scheduler configuration.
+        kwargs : Optional keyword arguments for the scheduler algorithm.
 
         Returns
         -------
-        None
+
         """
-        self.observatoryModel.configure(confdict)
-        self.observatoryModel2.configure(confdict)
+        survey_topology = SurveyTopology()
 
-    def configure_telescope(self, confdict):
+        survey_topology.num_general_props = 1
+        survey_topology.general_propos = ["Test"]
+        survey_topology.num_seq_props = 0
+        survey_topology.sequence_propos = []
 
-        self.observatoryModel.configure_telescope(confdict)
-        self.observatoryModel2.configure_telescope(confdict)
-
-    def configure_rotator(self, confdict):
-
-        self.observatoryModel.configure_rotator(confdict)
-        self.observatoryModel2.configure_rotator(confdict)
-
-    def configure_dome(self, confdict):
-
-        self.observatoryModel.configure_dome(confdict)
-        self.observatoryModel2.configure_dome(confdict)
-
-    def configure_optics(self, confdict):
-
-        self.observatoryModel.configure_optics(confdict)
-        self.observatoryModel2.configure_optics(confdict)
-
-    def configure_camera(self, confdict):
-
-        self.observatoryModel.configure_camera(confdict)
-        self.observatoryModel2.configure_camera(confdict)
-
-    def configure_slew(self, confdict):
-
-        self.observatoryModel.configure_slew(confdict)
-        self.observatoryModel2.configure_slew(confdict)
-
-    def configure_park(self, confdict):
-
-        self.observatoryModel.configure_park(confdict)
-        self.observatoryModel2.configure_park(confdict)
-
-    def start_survey(self, timestamp, night):
-        """This method begins the survey.
-
-        Parameters
-        ----------
-        timestamp : float
-        night : int
-
-        Returns
-        -------
-        None
-        """
-        self.start_time = timestamp
-
-        self.log.info("start_survey t=%.6f" % timestamp)
-
-        self.survey_started = True
-        self.sky.update(timestamp)
-        (sunset, sunrise) = self.sky.get_night_boundaries(self.params.night_boundary)
-        self.log.debug("start_survey sunset=%.6f sunrise=%.6f" % (sunset, sunrise))
-        # if round(sunset) <= round(timestamp) < round(sunrise):
-        if sunset <= timestamp < sunrise:
-            self.start_night(timestamp, night)
-
-        self.sunset_timestamp = sunset
-        self.sunrise_timestamp = sunrise
-
-    def end_survey(self):
-        """This method ends the survey.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-        self.log.info("end_survey")
-
-    def start_night(self, timestamp, night):
-        """This method is called once per night before observations begin.
-        It is not called if the observatory is undergoing downtime.
-        Parameters
-        ----------
-        timestamp : float
-        night : int
-
-        Returns
-        -------
-        None
-        """
-        timeprogress = (timestamp - self.start_time) / self.survey_duration_SECS
-        self.log.info("start_night t=%.6f, night=%d timeprogress=%.2f%%" %
-                      (timestamp, night, 100 * timeprogress))
-
-        self.isnight = True
-
-    def end_night(self, timestamp, night):
-        """This method is called once per night after observing completes.
-
-        Parameters
-        ----------
-        timestamp : float
-        night : int
-
-        Returns
-        -------
-        None
-        """
-        pass
-
-    def swap_filter(self, filter_to_unmount, filter_to_mount):
-
-        self.log.info("swap_filter swap %s=>cam=>%s" % (filter_to_mount, filter_to_unmount))
-
-        self.observatoryModel.swap_filter(filter_to_unmount)
-
-        self.unmounted_filter = filter_to_unmount
-        self.mounted_filter = filter_to_mount
-
-        return
-
-    def update_time(self, timestamp, night):
-            self.time = timestamp
-            self.observatoryModel.update_state(self.time)
-            if not self.survey_started:
-                self.start_survey(timestamp, night)
-
-            if self.isnight:
-                # if round(timestamp) >= round(self.sunrise_timestamp):
-                if timestamp >= self.sunrise_timestamp:
-                    self.end_night(timestamp, night)
-            else:
-                # if round(timestamp) >= round(self.sunset_timestamp):
-                if timestamp >= self.sunset_timestamp:
-                    self.start_night(timestamp, night)
-            return self.isnight
-
-    def get_need_filter_swap(self):
-        """When scheduler determines that a filter swap is needed,
-        this shall return a tuple where the first element is a TRUE value,
-        and the second and third elements are single-character strings identifying
-        which filter to remove from the carousel, and which filter to add, respectively.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        Tuple (bool, str, str)
-        """
-        return (self.need_filter_swap, self.filter_to_unmount, self.filter_to_mount)
-
-    def update_internal_conditions(self, observatory_state, night):
-
-        if observatory_state.unmountedfilters != self.observatoryModel.current_state.unmountedfilters:
-            unmount = observatory_state.unmountedfilters[0]
-            mount = self.observatoryModel.current_state.unmountedfilters[0]
-            self.swap_filter(unmount, mount)
-        self.time = observatory_state.time
-        self.observatoryModel.set_state(observatory_state)
-        self.observatoryState.set(observatory_state)
-
-    def update_external_conditions(self, cloud, seeing):
-
-        self.cloud = cloud
-        self.seeing = seeing
-
-        return
+        return survey_topology
 
     def cold_start(self, observations):
         """Rebuilds the internal state of the scheduler from a list of observations.
@@ -292,6 +92,15 @@ class Driver(object):
         """
         raise NotImplemented
 
+    def update_conditions(self):
+        """
+
+        Returns
+        -------
+
+        """
+        pass
+
     def select_next_target(self):
         """Picks a target and returns it as a target object.
 
@@ -304,7 +113,15 @@ class Driver(object):
         Target
         """
 
-        raise NotImplemented
+        target = Target()
+
+        target.targetid = 0
+        target.num_exp = 2
+        target.exp_times = [15.0, 15.0]
+        target.num_props = 1
+        target.propid_list = [0]
+
+        return target
 
     def register_observation(self, observation):
         """Validates observation and returns a list of successfully completed observations.
@@ -318,4 +135,4 @@ class Driver(object):
         Python list of one or more Observations
         """
 
-        raise NotImplemented
+        return [observation]

--- a/python/lsst/ts/scheduler/main.py
+++ b/python/lsst/ts/scheduler/main.py
@@ -27,7 +27,8 @@ __all__ = ["Main"]
 
 class Main(object):
 
-    def __init__(self, options, driver=Driver()):
+    def __init__(self, options, driver=None):
+        warnings.warn('DeprecationWarning! Use of Main will be deprecated. Use Model instead')
         self.log = logging.getLogger("schedulerMain")
 
         main_confdict = read_conf_file(conf_file_path(__name__, "conf", "scheduler", "main.conf"))
@@ -53,7 +54,10 @@ class Main(object):
                 self.log.debug('{}'.format(setting))
 
         self.sal = SALUtils(options.timeout)
-        self.schedulerDriver = driver
+        if driver is None:
+            self.schedulerDriver = Driver({}, {})
+        else:
+            self.schedulerDriver = driver
         self.config = SchedulerConfig()
 
         self.meascount = 0

--- a/python/lsst/ts/scheduler/model.py
+++ b/python/lsst/ts/scheduler/model.py
@@ -38,6 +38,27 @@ class ModelParameters(pexConfig.Config):
                                   "`importlib.import_module()`. Model will look for a subclass of Driver "
                                   "class inside the module.", str,
                                   default='lsst.ts.scheduler.driver')
+    night_boundary = pexConfig.Field('Solar altitude (degrees) when it is considered night.', float)
+    new_moon_phase_threshold = pexConfig.Field('New moon phase threshold for swapping to dark time filter.',
+                                               float)
+    startup_type = pexConfig.ChoiceField("The method used to startup the scheduler.", str,
+                                         default='HOT',
+                                         allowed={"HOT": "Hot start, this means the scheduler is started up from "
+                                                         "scratch",
+                                                  "WARM": "Reads the scheduler state from a previously saved "
+                                                          "internal state.",
+                                                  "COLD": "Rebuilds scheduler state from observation database.", })
+    startup_database = pexConfig.Field("Path to the file holding scheduler state or observation database "
+                                       "to be used on WARM or COLD start.", str, default='')
+
+    def setDefaults(self):
+        """Set defaults for the LSST Scheduler's Driver.
+        """
+        self.driver_type = 'lsst.ts.scheduler.driver'
+        self.night_boundary = -12.0
+        self.new_moon_phase_threshold = 20.0
+        self.startup_type = 'HOT'
+        self.startup_database = ''
 
 
 class Model:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -34,8 +34,7 @@ class TestSchedulerModel(unittest.TestCase):
         assert m.send_valid_settings().find('master') != -1
 
     def test_init_models(self):
-        """
-        This unit test will check that the basic models are initialized by the model.
+        """This unit test will check that the basic models are initialized by the model.
 
         Returns
         -------
@@ -55,6 +54,21 @@ class TestSchedulerModel(unittest.TestCase):
         for telemetry in telemetry_list:
             assert telemetry in m.raw_telemetry
 
+    def test_configure(self):
+        """Test that it is possible to configure model.
+
+        Returns
+        -------
+
+        """
+        m = Model()
+
+        m.configure('master')
+
+        assert m.current_setting == 'master'
+        assert m.driver is not None
+
+        # TODO: One could now check that all the settings available are valid.
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,34 +6,54 @@ from lsst.ts.dateloc import ObservatoryLocation
 from lsst.ts.observatory.model import ObservatoryModel
 from lsst.ts.scheduler.kernel import conf_file_path, read_conf_file
 from lsst.ts.scheduler import Driver
+from lsst.ts.observatory.model import Target, Observation
+from lsst.ts.scheduler.kernel import SurveyTopology
 
-@unittest.skip('Cannot run this as-is: needs updating')
+
 class TestSchedulerDriver(unittest.TestCase):
 
     def setUp(self):
         logging.getLogger().setLevel(logging.WARN)
-        conf_path = conf_file_path(__name__, "conf")
-        self.driver = Driver()
 
-        driver_conf_file = os.path.join(conf_path, "scheduler", "driver.conf")
-        survey_conf_file = os.path.join(conf_path, "survey", "test_survey.conf")
+        # Initialize driver with empty models of raw_telemetry
+        self.driver = Driver(models={}, raw_telemetry={})
 
-        driver_confdict = read_conf_file(driver_conf_file)
-        obs_site_confdict = ObservatoryLocation.get_configure_dict()
-        obs_model_confdict = ObservatoryModel.get_configure_dict()
+        # driver_conf_file = os.path.join(conf_path, "scheduler", "driver.conf")
+        # survey_conf_file = os.path.join(conf_path, "survey", "test_survey.conf")
 
-        self.driver.configure(driver_confdict)
-        self.driver.configure_location(obs_site_confdict)
-        self.driver.configure_observatory(obs_model_confdict)
+        # driver_confdict = read_conf_file(driver_conf_file)
+        # obs_site_confdict = ObservatoryLocation.get_configure_dict()
+        # obs_model_confdict = ObservatoryModel.get_configure_dict()
 
-        self.driver.configure_survey(survey_conf_file)
+        # self.driver.configure(driver_confdict)
+        # self.driver.configure_location(obs_site_confdict)
+        # self.driver.configure_observatory(obs_model_confdict)
+        #
+        # self.driver.configure_survey(survey_conf_file)
 
+    def test_configure_scheduler(self):
+        survey_topology = self.driver.configure_scheduler()
+
+        assert isinstance(survey_topology, SurveyTopology)
+        assert survey_topology.num_general_props != 0
+        assert len(survey_topology.general_propos) == survey_topology.num_general_props
+        assert len(survey_topology.sequence_propos) == survey_topology.num_seq_props
+
+    def test_select_next_target(self):
+        target = self.driver.select_next_target()
+
+        assert isinstance(target, Target)
+        assert target.num_exp > 0
+        assert len(target.exp_times) == target.num_exp
+
+    @unittest.skip('Cannot run this as-is: needs updating')
     def test_init(self):
 
         self.assertEqual(len(self.driver.fields_dict), 5292)
         self.assertEqual(len(self.driver.science_proposal_list), 1)
         self.assertEqual(self.driver.science_proposal_list[0].name, "weak_lensing")
 
+    @unittest.skip('Cannot run this as-is: needs updating')
     def test_compute_slewtime_cost(self):
 
         self.assertAlmostEquals(self.driver.compute_slewtime_cost(0), -0.034, delta=1e-3)
@@ -48,6 +68,7 @@ class TestSchedulerDriver(unittest.TestCase):
         self.assertAlmostEquals(self.driver.compute_slewtime_cost(150), 1.000, delta=1e-3)
         self.assertAlmostEquals(self.driver.compute_slewtime_cost(200), 1.350, delta=1e-3)
 
+    @unittest.skip('Cannot run this as-is: needs updating')
     def test_startsurvey_startnight(self):
 
         lsst_start_timestamp = 1640995200.0


### PR DESCRIPTION
it was suggested that Driver should not host models, which should be at the higher level CSC Model Controller. We also agreed on a simplified version of the interface with only a few methods. The current driver will implement some of those methods to return some mock values so they can be used for unit testing. This update will break the current driver so we will open a release branch to host these and future changes.