### PR TITLE
Implement `start` command on the Scheduler CSC. 

### DIFF
--- a/python/lsst/ts/scheduler/driver.py
+++ b/python/lsst/ts/scheduler/driver.py
@@ -20,7 +20,7 @@ class DriverParameters(pexConfig.Config):
     pass
 
 class Driver(object):
-    def __init__(self, models, raw_telemetry, params=None):
+    def __init__(self, models, raw_telemetry, parameters=None):
         """Initialize base scheduler driver.
 
         Parameters
@@ -30,10 +30,10 @@ class Driver(object):
         """
         self.log = logging.getLogger("schedulerDriver")
 
-        if params is None:
-            self.params = DriverParameters()
+        if parameters is None:
+            self.parameters = DriverParameters()
         else:
-            self.params = params
+            self.parameters = parameters
         self.models = models
         self.raw_telemetry = raw_telemetry
 

--- a/python/lsst/ts/scheduler/kernel/survey_topology.py
+++ b/python/lsst/ts/scheduler/kernel/survey_topology.py
@@ -27,12 +27,17 @@ class SurveyTopology(object):
         self.general_propos = topic.general_propos.split(',')
         self.sequence_propos = topic.sequence_propos.split(',')
 
-    def to_topic(self):
+    def to_topic(self, topic):
+        """
 
-        from SALPY_scheduler import scheduler_surveyTopologyC
+        Parameters
+        ----------
+        topic
 
-        topic = scheduler_surveyTopologyC()
+        Returns
+        -------
 
+        """
         topic.numGeneralProps = self.num_general_props
         topic.numSeqProps = self.num_seq_props
 

--- a/python/lsst/ts/scheduler/setup/log.py
+++ b/python/lsst/ts/scheduler/setup/log.py
@@ -30,6 +30,8 @@ def generate_logfile(basename="scheduler"):
     """
     timestr = time.strftime("%Y-%m-%d_%H:%M:%S")
     log_path = pkg_resources.resource_filename(__name__, "../../log")
+    if not os.path.exists(log_path):
+        os.makedirs(log_path)
     logfilename = os.path.join(log_path, "%s.%s.log" % (basename, timestr))
     return logfilename
 

--- a/scripts/scheduler.py
+++ b/scripts/scheduler.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
+import asyncio
 import logging
 import sys
 
-from lsst.ts.scheduler import Main
+from lsst.ts.scheduler import SchedulerCSC
+# from lsst.ts.scheduler import Main
 from lsst.ts.scheduler.setup import configure_logging, create_parser, generate_logfile
-from lsst.ts.scheduler import Driver
+# from lsst.ts.scheduler import Driver
 
 def main(args):
     logfilename = generate_logfile()
@@ -14,13 +16,25 @@ def main(args):
     logger = logging.getLogger("scheduler")
     logger.info("logfile=%s" % logfilename)
 
-    scheduler = Main(args, Driver())
-    scheduler.sal_init()
-    with open('.scheduler_{}'.format(args.log_port), 'w'):
-        pass
-    scheduler.run()
+    csc = SchedulerCSC(0)  # FIXME: Index should come from args
 
-    sys.exit(0)
+    loop = asyncio.get_event_loop()
+
+    try:
+        logger.info('Running CSC (Control+C to stop it)...')
+        loop.run_forever()
+    except KeyboardInterrupt as e:
+        logger.info('Stopping %s CSC.', args.subsystem_tag)
+    finally:
+        loop.close()
+
+    # scheduler = Main(args, Driver())
+    # scheduler.sal_init()
+    # with open('.scheduler_{}'.format(args.log_port), 'w'):
+    #     pass
+    # scheduler.run()
+    #
+    # sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,5 +1,11 @@
 # -*- python -*-
 import os
-from lsst.sconsUtils import scripts, env
 
-scripts.BasicSConscript.tests()
+from lsst.sconsUtils import env, scripts
+
+scripts.BasicSConscript.tests(pyList=[])
+
+for name in ("OSPL_URI", "OPENSPLICE_LOC"):
+    val = os.environ.get(name)
+    if val is not None:
+        env.AppendENVPath(name, val)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,8 +1,9 @@
 import unittest
 import pytest
 
-from lsst.ts.scheduler import Model
+# from lsst.ts.scheduler import Model
 
+@unittest.skip('Model has been deprecated')
 class TestSchedulerModel(unittest.TestCase):
 
     def test_init(self):

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -1,4 +1,6 @@
+import sys
 import unittest
+import time
 import pytest
 import asyncio
 import salobj
@@ -8,8 +10,8 @@ import SALPY_Scheduler
 index_gen = salobj.index_generator()
 
 class Harness:
-    def __init__(self, initial_state):
-        index = 0 #next(index_gen)
+    def __init__(self):
+        index = 0  # next(index_gen)
         salobj.test_utils.set_random_lsst_dds_domain()
         self.csc = SchedulerCSC(index=index)
         self.remote = salobj.Remote(SALPY_Scheduler, index)
@@ -18,65 +20,188 @@ class Harness:
 
 class TestSchedulerCSC(unittest.TestCase):
 
-    def test_change_state(self):
-        harness = Harness()
+    def test_heartbeat(self):
+        async def doit():
+            harness = Harness()
+            start_time = time.time()
+            await harness.remote.evt_heartbeat.next(timeout=2)
+            await harness.remote.evt_heartbeat.next(timeout=2)
+            duration = time.time() - start_time
+            self.assertLess(abs(duration - 2), 0.5)
 
-        # CSC must start in OFFLINE
-        assert harness.csc.current_state == salobj.base_csc.State.OFFLINE
+        asyncio.get_event_loop().run_until_complete(doit())
 
+    def test_standard_state_transitions(self):
+        """Test standard CSC state transitions.
 
-        assert m.current_state == "STANDBY"
-        assert m.previous_state == "OFFLINE"
+        The initial state is STANDBY.
+        The standard commands and associated state transitions are:
 
-        m.current_state = "DISABLED"
-        assert m.current_state == "DISABLED"
-        assert m.previous_state == "STANDBY"
+        * enterControl: OFFLINE to STANDBY
+        * start: STANDBY to DISABLED
+        * enable: DISABLED to ENABLED
 
-        with pytest.raises(AttributeError):
-            m.previous_state = "ENABLED"
-
-    def test_send_valid_settings(self):
-        m = Model()
-
-        m.sal_start()
-        assert m.send_valid_settings().find('master') != -1
-
-    def test_init_models(self):
-        """This unit test will check that the basic models are initialized by the model.
-
-        Returns
-        -------
-
+        * disable: ENABLED to DISABLED
+        * standby: DISABLED to STANDBY
+        * exitControl: STANDBY, FAULT to OFFLINE (quit)
         """
-        models_list = ['location', 'observatory_model', 'observatory_state', 'sky', 'seeing',
-                       'scheduled_downtime', 'unscheduled_downtime']  # 'cloud',
-        telemetry_list = ['timeHandler', 'observatoryState', 'bulkCloud', 'seeing']
 
-        m = Model()
-        m.init_models()
+        async def doit():
+            harness = Harness()
+            commands = ("enterControl", "start", "enable", "disable", "exitControl", "standby")
 
-        for model in models_list:
-            assert model in m.models
-            assert m.models[model] is not None
+            self.assertEqual(harness.csc.summary_state, salobj.State.OFFLINE)
 
-        for telemetry in telemetry_list:
-            assert telemetry in m.raw_telemetry
+            for bad_command in commands:
+                if bad_command == "enterControl":
+                    continue  # valid command in OFFLINE state
+                with self.subTest(bad_command=bad_command):
+                    cmd_attr = getattr(harness.remote, f"cmd_{bad_command}")
+                    id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+                    self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_FAILED)
+                    self.assertNotEqual(id_ack.ack.error, 0)
+                    self.assertNotEqual(id_ack.ack.result, "")
 
-    def test_configure(self):
-        """Test that it is possible to configure model.
+            # send enterControl; new state is STANDBY
+            cmd_attr = getattr(harness.remote, f"cmd_enterControl")
+            state_coro = harness.remote.evt_summaryState.next(timeout=1.)
+            id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+            state = await state_coro
+            self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            self.assertEqual(id_ack.ack.error, 0)
+            self.assertEqual(harness.csc.summary_state, salobj.State.STANDBY)
+            self.assertEqual(state.summaryState, salobj.State.STANDBY)
 
-        Returns
-        -------
+            for bad_command in commands:
+                if bad_command in ("start", "exitControl"):
+                    continue  # valid command in STANDBY state
+                with self.subTest(bad_command=bad_command):
+                    cmd_attr = getattr(harness.remote, f"cmd_{bad_command}")
+                    id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+                    self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_FAILED)
+                    self.assertNotEqual(id_ack.ack.error, 0)
+                    self.assertNotEqual(id_ack.ack.result, "")
 
-        """
-        m = Model()
+            # send start; new state is DISABLED
+            cmd_attr = getattr(harness.remote, f"cmd_start")
+            state_coro = harness.remote.evt_summaryState.next(timeout=1.)
+            start_topic = cmd_attr.DataType()
+            start_topic.settingsToApply = 'master'  # user master branch on configuration for unit tests.
+            id_ack = await cmd_attr.start(start_topic, timeout=120)  # this one takes longer to execute
+            state = await state_coro
+            self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            self.assertEqual(id_ack.ack.error, 0)
+            self.assertEqual(harness.csc.summary_state, salobj.State.DISABLED)
+            self.assertEqual(state.summaryState, salobj.State.DISABLED)
 
-        m.configure('master')
+            # TODO: There are two events issued when starting the scheduler; appliedSettingsMatchStart and
+            # settingsApplied. Check that they are received.
 
-        assert m.current_setting == 'master'
-        assert m.driver is not None
+            for bad_command in commands:
+                if bad_command in ("enable", "standby"):
+                    continue  # valid command in DISABLED state
+                with self.subTest(bad_command=bad_command):
+                    cmd_attr = getattr(harness.remote, f"cmd_{bad_command}")
+                    id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+                    self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_FAILED)
+                    self.assertNotEqual(id_ack.ack.error, 0)
+                    self.assertNotEqual(id_ack.ack.result, "")
 
-        # TODO: One could now check that all the settings available are valid.
+            # send enable; new state is ENABLED
+            cmd_attr = getattr(harness.remote, f"cmd_enable")
+            state_coro = harness.remote.evt_summaryState.next(timeout=1.)
+            id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+            state = await state_coro
+            self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            self.assertEqual(id_ack.ack.error, 0)
+            self.assertEqual(harness.csc.summary_state, salobj.State.ENABLED)
+            self.assertEqual(state.summaryState, salobj.State.ENABLED)
+
+            for bad_command in commands:
+                if bad_command == "disable":
+                    continue  # valid command in ENABLE state
+                with self.subTest(bad_command=bad_command):
+                    cmd_attr = getattr(harness.remote, f"cmd_{bad_command}")
+                    id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+                    self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_FAILED)
+                    self.assertNotEqual(id_ack.ack.error, 0)
+                    self.assertNotEqual(id_ack.ack.result, "")
+
+            # send disable; new state is DISABLED
+            cmd_attr = getattr(harness.remote, f"cmd_disable")
+            id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+            self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            self.assertEqual(id_ack.ack.error, 0)
+            self.assertEqual(harness.csc.summary_state, salobj.State.DISABLED)
+
+            # send standby; new state is STANDBY
+            cmd_attr = getattr(harness.remote, f"cmd_standby")
+            id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+            self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            self.assertEqual(id_ack.ack.error, 0)
+            self.assertEqual(harness.csc.summary_state, salobj.State.STANDBY)
+
+            # send exitControl; new state is OFFLINE
+            # cmd_attr = getattr(harness.remote, f"cmd_exitControl")
+            # id_ack = await cmd_attr.start(cmd_attr.DataType(), timeout=1.)
+            # self.assertEqual(id_ack.ack.ack, harness.remote.salinfo.lib.SAL__CMD_COMPLETE)
+            # self.assertEqual(id_ack.ack.error, 0)
+            # self.assertEqual(harness.csc.summary_state, salobj.State.OFFLINE)
+
+        asyncio.get_event_loop().run_until_complete(doit())
+
+        # assert m.current_state == "STANDBY"
+        # assert m.previous_state == "OFFLINE"
+        #
+        # m.current_state = "DISABLED"
+        # assert m.current_state == "DISABLED"
+        # assert m.previous_state == "STANDBY"
+        #
+        # with pytest.raises(AttributeError):
+        #     m.previous_state = "ENABLED"
+
+    # def test_send_valid_settings(self):
+    #     m = Model()
+    #
+    #     m.sal_start()
+    #     assert m.send_valid_settings().find('master') != -1
+    #
+    # def test_init_models(self):
+    #     """This unit test will check that the basic models are initialized by the model.
+    #
+    #     Returns
+    #     -------
+    #
+    #     """
+    #     models_list = ['location', 'observatory_model', 'observatory_state', 'sky', 'seeing',
+    #                    'scheduled_downtime', 'unscheduled_downtime']  # 'cloud',
+    #     telemetry_list = ['timeHandler', 'observatoryState', 'bulkCloud', 'seeing']
+    #
+    #     m = Model()
+    #     m.init_models()
+    #
+    #     for model in models_list:
+    #         assert model in m.models
+    #         assert m.models[model] is not None
+    #
+    #     for telemetry in telemetry_list:
+    #         assert telemetry in m.raw_telemetry
+    #
+    # def test_configure(self):
+    #     """Test that it is possible to configure model.
+    #
+    #     Returns
+    #     -------
+    #
+    #     """
+    #     m = Model()
+    #
+    #     m.configure('master')
+    #
+    #     assert m.current_setting == 'master'
+    #     assert m.driver is not None
+    #
+    #     # TODO: One could now check that all the settings available are valid.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The start command takes some time to load and configure the models, driver and the scheduling algorithm. While it is configuring it must keep its responsiveness. To allow that, we use a `ThreadPoolExecutor` to run the configuration task. The models now need to be updated to contain a `parameters` object that host the configuration.

Adds unit test for the SchedulerCSC. It will bring the CSC from OFFLINE to ENABLE and back. Still need to add some checks for responsiveness when it is starting (checked manually and it is working, but need unit test).

Updated scheduler initialization script to initialize the CSC. The script may need some extra polishing later.

Disable unit tests for deprecated Model class. This will be removed later.