### PR TITLE
DM-28417 Support AT observing run 2020/01

### DIFF
--- a/python/lsst/ts/scheduler/driver/sequential.py
+++ b/python/lsst/ts/scheduler/driver/sequential.py
@@ -60,7 +60,11 @@ class SequentialTarget(DriverTarget):
         config_str: str
         """
 
-        return yaml.safe_dump(self.config)
+        return yaml.safe_dump(
+            self.config["script_config"]
+            if "script_config" in self.config
+            else self.config
+        )
 
 
 class SequentialParameters(DriverParameters):
@@ -284,6 +288,10 @@ properties:
               filter:
                 description: Filters for this exposure.
                 type: string
+        script_config:
+          type: object
+          description: Script configuration.
+          additionalProperties: true
       # Disable support for providing name only. Need to check how to support it.
       # if:
       #   properties:


### PR DESCRIPTION
Minor improvements to sequential driver.
Include a `script_config` section on Sequential driver target configuration.
If the target specify that section, the config is sent to the script instead of parsing information from the target. 