### PR TITLE
Move from rubin_sim to rubin_scheduler

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           $CONDA/bin/conda install -c lsstts ts-pre-commit-config -y
           $CONDA/bin/conda install -c conda-forge pre-commit -y
-          $CONDA/bin/generate_pre_commit_conf
+          $CONDA/bin/generate_pre_commit_conf --skip-pre-commit-install
 
       - name: Run pre commit checks
         run: $CONDA/bin/pre-commit run --all

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ doc/py-api
 .flake8
 .isort.cfg
 .mypy.ini
+.clang-format
+.ruff.toml
+towncrier.toml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,8 @@ pipeline{
             steps{
                 sh """
                     source /home/saluser/.setup.sh
-                    mamba install -y -c lsstts ts-idl ts-utils ts-salobj ts-scriptqueue ts-observatory-model ts-astrosky-model ts-dateloc ts-observing rubin-sim
+                    mamba install -y -c lsstts ts-idl ts-utils ts-salobj ts-scriptqueue ts-observatory-model
+                    mamba install -y -c lsstts ts-astrosky-model ts-dateloc ts-observing rubin-scheduler
                     pip install -e .
                     pip install -r doc/requirements.txt
                     package-docs build

--- a/builder/jenkins_testing.sh
+++ b/builder/jenkins_testing.sh
@@ -25,24 +25,14 @@ source_eups="source eups-setups.sh"
 find_eups=$(${source_eups} 2>&1)
 if [ $? != 0 ]; then
 	echo "Installing necessary packages"
-	need_install=1
-	conda install -y lsst-sims-skybrightness enum34 mock pytest
+	conda install -y rubin-scheduler enum34 mock pytest
 	conda update astropy
-	git clone https://github.com/lsst/sims_skybrightness.git
+	scheduler-download-data --update
 else
 	echo "Updating packages"
-	cd ${WORKSPACE}/sims_skybrightness
-	git rebase -v
-	git fetch -p -t
-	cd ${WORKSPACE}
+	conda install rubin-scheduler
+	scheduler-download-data --update
 fi
 ${source_eups}
-if [ ${need_install} -eq 1 ]; then
-	eups declare sims_skybrightness git -r ${WORKSPACE}/sims_skybrightness -c
-fi
-setup sims_skybrightness
-cd ${WORKSPACE}/sims_skybrightness
-scons
-cd ${WORKSPACE}
 
 py.test

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,7 +23,7 @@ test:
     - ts-astrosky-model >=1.4
     - ts-dateloc
     - ts-observing
-    - rubin-sim =1
+    - rubin-scheduler
     - rsync
   source_files:
     - python
@@ -31,7 +31,7 @@ test:
     - setup.cfg
     - pyproject.toml
   commands:
-    - rs_download_data -d skybrightness,skybrightness_pre,throughputs,site_models
+    - scheduler_download_data --update
     - pytest -vsx
 
 requirements:
@@ -56,4 +56,4 @@ requirements:
     - ts-astrosky-model >=1.4
     - ts-dateloc
     - ts-observing
-    - rubin-sim =1
+    - rubin-scheduler

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,6 +15,11 @@ build:
 test:
   requires:
     - ts-conda-build =0.3
+    - astropy
+    - jsonschema
+    - numpy
+    - pandas
+    - yaml
     - ts-idl {{ idl_version }}
     - ts-utils
     - ts-salobj {{ salobj_version }}
@@ -49,6 +54,11 @@ requirements:
     - python {{ python }}
     - setuptools {{ setuptools }}
     - setuptools_scm {{ setuptools_scm }}
+    - astropy
+    - jsonschema
+    - numpy
+    - pandas
+    - yaml
     - ts-idl
     - ts-utils
     - ts-salobj

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,4 +14,4 @@ doxylink = {}  # Avoid warning: Could not find tag file _doxygen/doxygen.tag
 intersphinx_mapping["ts_xml"] = ("https://ts-xml.lsst.io", None)  # type: ignore # noqa
 intersphinx_mapping["ts_salobj"] = ("https://ts-salobj.lsst.io", None)  # type: ignore # noqa
 intersphinx_mapping["ts_scriptqueue"] = ("https://ts-scriptqueue.lsst.io", None)  # type: ignore # noqa
-intersphinx_mapping["rubin_sim"] = ("https://rubin-sim.lsst.io", None)  # type: ignore # noqa
+intersphinx_mapping["rubin_scheduler"] = ("https://rubin-scheduler.lsst.io", None)  # type: ignore # noqa

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -12,6 +12,8 @@ v2.0.0
 .. It will be spread over several PRs untill the feature is fully implemented.
 .. In the meantime use Release Candidate (in the develop branch) to deploy at the summit.
 
+* Moves from rubin-sim package to rubin-scheduler. The rubin-scheduler package contains all of the scheduling-related code from rubin-sim, but without MAF. This reduces the dependencies typically installed with rubin-sim, as well as reduces the default data download to only that required to run the scheduler.
+
 * Update documentation.
 
 * Add support for running CSC with Kafka version of salobj.
@@ -97,7 +99,8 @@ v2.0.0
   * Use conditional schema to match the selected driver to its configuration, making the appropriate session required according to the selected driver.
   * Make all sub-schemas fixed, do not accept additional properties.
 
-* In ``utils/fbs_utils.py``, minor cosmetic update in ``SchemaConverter`` to extract the code that converts and opsim database into a pandas dataframe into its own method.
+* In ``utils/fbs_utils.py``, moves to inheriting from rubin_scheduler.scheduler.SchemaConverter, while extending the class to add a method to convert from an opsim database into a pandas dataframe (only).
+
 
 * In ``utils/csc_utils.py``:
 

--- a/python/lsst/ts/scheduler/driver/feature_scheduler.py
+++ b/python/lsst/ts/scheduler/driver/feature_scheduler.py
@@ -33,10 +33,10 @@ import pandas
 import yaml
 from astropy.time import Time
 from lsst.ts.utils import index_generator
-from rubin_sim.scheduler.features import Conditions
-from rubin_sim.scheduler.utils import empty_observation
-from rubin_sim.site_models import Almanac
-from rubin_sim.utils import _ra_dec2_hpid
+from rubin_scheduler.scheduler.features import Conditions
+from rubin_scheduler.scheduler.utils import empty_observation
+from rubin_scheduler.site_models import Almanac
+from rubin_scheduler.utils import _ra_dec2_hpid
 
 from ..utils.fbs_utils import SchemaConverter, make_fbs_observation_from_target
 from . import Driver, DriverParameters

--- a/python/lsst/ts/scheduler/model.py
+++ b/python/lsst/ts/scheduler/model.py
@@ -118,9 +118,9 @@ class Model:
 
         # Dictionary to store information about the scripts put on the queue
         self.script_info: dict[int, BaseDdsDataType] = dict()
-        self._block_scripts_final_state: dict[
-            uuid.UUID, dict[int, asyncio.Future]
-        ] = dict()
+        self._block_scripts_final_state: dict[uuid.UUID, dict[int, asyncio.Future]] = (
+            dict()
+        )
 
         # Dictionary to store observing blocks
         self.observing_blocks: dict[str, observing.ObservingBlock] = dict()
@@ -266,9 +266,9 @@ class Model:
         for observing_block_file in path_observing_blocks.glob("*.json"):
             observing_block = observing.ObservingBlock.parse_file(observing_block_file)
             self.observing_blocks[observing_block.program] = observing_block
-            self.observing_blocks_status[
-                observing_block.program
-            ] = await self._get_block_status(program=observing_block.program)
+            self.observing_blocks_status[observing_block.program] = (
+                await self._get_block_status(program=observing_block.program)
+            )
 
     async def validate_observing_blocks(
         self, observing_scripts_config_validator: ValidationRules
@@ -309,9 +309,9 @@ class Model:
                         f"Successfully validated script {script.name} from {block_id} "
                         f"with:\n{script.parameters}"
                     )
-                    self.observing_blocks_status[
-                        block_id
-                    ].status = BlockStatus.AVAILABLE
+                    self.observing_blocks_status[block_id].status = (
+                        BlockStatus.AVAILABLE
+                    )
 
     def get_valid_observing_blocks(self) -> list[str]:
         """Get list of valid observing blocks.

--- a/python/lsst/ts/scheduler/model.py
+++ b/python/lsst/ts/scheduler/model.py
@@ -39,8 +39,8 @@ from lsst.ts.dateloc import ObservatoryLocation
 from lsst.ts.idl.enums import Script
 from lsst.ts.observatory.model import ObservatoryModel, ObservatoryState
 from lsst.ts.salobj.type_hints import BaseDdsDataType
-from rubin_sim.site_models.cloud_model import CloudModel
-from rubin_sim.site_models.seeing_model import SeeingModel
+from rubin_scheduler.site_models.cloud_model import CloudModel
+from rubin_scheduler.site_models.seeing_model import SeeingModel
 
 from .driver import Driver, DriverFactory, DriverType
 from .driver.driver_target import DriverTarget

--- a/python/lsst/ts/scheduler/scheduler_csc.py
+++ b/python/lsst/ts/scheduler/scheduler_csc.py
@@ -1236,7 +1236,11 @@ class SchedulerCSC(salobj.ConfigurableCsc):
 
         task_name = "lock_target_loop_and_check_targets"
 
-        if task_name not in self._tasks or self._tasks[task_name].done():
+        task = self._tasks.get(task_name, None)
+        if task is None:
+            task = utils.make_done_future()
+
+        if task.done():
             self._tasks[task_name] = asyncio.create_task(
                 self.lock_target_loop_and_check_targets()
             )

--- a/python/lsst/ts/scheduler/scheduler_csc.py
+++ b/python/lsst/ts/scheduler/scheduler_csc.py
@@ -1581,7 +1581,11 @@ class SchedulerCSC(salobj.ConfigurableCsc):
         async with self.current_scheduler_state(publish_lfoa=True):
             self.log.debug(f"Target queue contains {len(self.targets_queue)} targets.")
 
-            async for observatory_time, wait_time, target in self.model.generate_target_queue(
+            async for (
+                observatory_time,
+                wait_time,
+                target,
+            ) in self.model.generate_target_queue(
                 targets_queue=self.targets_queue,
                 max_targets=self.parameters.n_targets + 1,
             ):

--- a/python/lsst/ts/scheduler/scheduler_csc.py
+++ b/python/lsst/ts/scheduler/scheduler_csc.py
@@ -42,7 +42,7 @@ from lsst.ts.dateloc import version as dateloc_version
 from lsst.ts.idl.enums import Scheduler, ScriptQueue
 from lsst.ts.observatory.model import version as obs_mod_version
 from lsst.ts.observing import ObservingBlock, ObservingScript
-from rubin_sim.version import __version__ as rubin_sim_version
+from rubin_scheduler.version import __version__ as rubin_scheduler_version
 
 from . import CONFIG_SCHEMA, __version__
 from .driver.driver_target import DriverTarget
@@ -119,9 +119,8 @@ class SchedulerCSC(salobj.ConfigurableCsc):
         - `observatory_model` : lsst.ts.observatory.model.ObservatoryModel
         - `observatory_state` : lsst.ts.observatory.model.ObservatoryState
         - `sky` : lsst.ts.astrosky.model.AstronomicalSkyModel
-        - `seeing` : lsst.sims.seeingModel.SeeingModel
-        - `scheduled_downtime` : lsst.sims.downtimeModel.ScheduleDowntime
-        - `unscheduled_downtime` : lsst.sims.downtimeModel.UnschedulerDowntime
+        - `seeing` : rubin_scheduler.site_models.SeeingModel
+        - `downtime` : rubin_scheduler.site_models.DowntimeModel
     raw_telemetry: {`str`: :object:}
         Raw, as in unparsed data that is recieved over SAL. The SchedulerCSC
         parses self.raw_telemtry and formats the data into self.models.
@@ -1104,10 +1103,10 @@ class SchedulerCSC(salobj.ConfigurableCsc):
                 scheduler=self.parameters.driver_type,
                 observatoryModel=obs_mod_version.__version__,
                 observatoryLocation=dateloc_version.__version__,
-                seeingModel=rubin_sim_version,
-                cloudModel=rubin_sim_version,
+                seeingModel=rubin_scheduler_version,
+                cloudModel=rubin_scheduler_version,
                 skybrightnessModel=astrosky_version.__version__,
-                downtimeModel=rubin_sim_version,
+                downtimeModel=rubin_scheduler_version,
                 force_output=True,
             )
         else:

--- a/python/lsst/ts/scheduler/utils/fbs_utils.py
+++ b/python/lsst/ts/scheduler/utils/fbs_utils.py
@@ -28,145 +28,19 @@ import sqlite3
 
 import numpy as np
 import pandas as pd
-from rubin_sim.scheduler.utils import empty_observation
+import rubin_scheduler.scheduler.utils as rs_sched_utils
 
 from ..driver.driver_target import DriverTarget
 
 
-class SchemaConverter:
+class SchemaConverter(rs_sched_utils.SchemaConverter):
     """Record how to convert an observation array to the standard
     opsim schema.
+
+    Extends rubin_scheduler.scheduler.utils.SchemaConverter with
+    a method to read an opsim database and return a dataframe instead
+    of an observation array.
     """
-
-    def __init__(self) -> None:
-        # Conversion dictionary, keys are opsim schema, values are
-        # observation dtype names
-        self.convert_dict = {
-            "observationId": "ID",
-            "night": "night",
-            "observationStartMJD": "mjd",
-            "observationStartLST": "lmst",
-            "numExposures": "nexp",
-            "visitTime": "visittime",
-            "visitExposureTime": "exptime",
-            "proposalId": "survey_id",
-            "fieldId": "field_id",
-            "fieldRA": "RA",
-            "fieldDec": "dec",
-            "altitude": "alt",
-            "azimuth": "az",
-            "filter": "filter",
-            "airmass": "airmass",
-            "skyBrightness": "skybrightness",
-            "cloud": "clouds",
-            "seeingFwhm500": "FWHM_500",
-            "seeingFwhmGeom": "FWHM_geometric",
-            "seeingFwhmEff": "FWHMeff",
-            "fiveSigmaDepth": "fivesigmadepth",
-            "slewTime": "slewtime",
-            "slewDistance": "slewdist",
-            "paraAngle": "pa",
-            "rotTelPos": "rotTelPos",
-            "rotTelPos_backup": "rotTelPos_backup",
-            "rotSkyPos": "rotSkyPos",
-            "rotSkyPos_desired": "rotSkyPos_desired",
-            "moonRA": "moonRA",
-            "moonDec": "moonDec",
-            "moonAlt": "moonAlt",
-            "moonAz": "moonAz",
-            "moonDistance": "moonDist",
-            "moonPhase": "moonPhase",
-            "sunAlt": "sunAlt",
-            "sunAz": "sunAz",
-            "solarElong": "solarElong",
-            "note": "note",
-        }
-        # Column(s) not bothering to remap:  'observationStartTime': None,
-        self.inv_map = {v: k for k, v in self.convert_dict.items()}
-        # angles to convert
-        self.angles_rad2deg = [
-            "fieldRA",
-            "fieldDec",
-            "altitude",
-            "azimuth",
-            "slewDistance",
-            "paraAngle",
-            "rotTelPos",
-            "rotSkyPos",
-            "rotSkyPos_desired",
-            "rotTelPos_backup",
-            "moonRA",
-            "moonDec",
-            "moonAlt",
-            "moonAz",
-            "moonDistance",
-            "sunAlt",
-            "sunAz",
-            "sunRA",
-            "sunDec",
-            "solarElong",
-            "cummTelAz",
-        ]
-        # Put LMST into degrees too
-        self.angles_hours2deg = ["observationStartLST"]
-
-    def obs2opsim(
-        self,
-        obs_array: np.ndarray,
-        filename: str,
-    ) -> None:
-        """Convert an array of observations into a pandas dataframe
-        with Opsim schema and store it in a sqlite database.
-
-        Parameters
-        ----------
-        obs_array : `np.ndarray`
-            Array of observations.
-        filename : `str`
-            Name of the database file.
-        """
-
-        df = pd.DataFrame(obs_array)
-        df = df.rename(index=str, columns=self.inv_map)
-        for colname in self.angles_rad2deg:
-            df[colname] = np.degrees(df[colname])
-        for colname in self.angles_hours2deg:
-            df[colname] = df[colname] * 360.0 / 24.0
-
-        if filename is not None:
-            con = sqlite3.connect(filename)
-            df.to_sql(
-                "observations",
-                con,
-                if_exists="append",
-                index=False,
-            )
-
-    def opsim2obs(self, filename: str) -> np.ndarray:
-        """Read an opsim database and return an observation array.
-
-        Parameters
-        ----------
-        filename : `str`
-            Path to the observation database.
-
-        Returns
-        -------
-        `np.ndarray`
-            A numpy named array with observations. The format is defined by
-            the feature scheduler observation.
-        """
-
-        df = self.opsim2df(filename)
-
-        blank = empty_observation()
-        final_result = np.empty(df.shape[0], dtype=blank.dtype)
-
-        for i, key in enumerate(df.columns):
-            if key in self.inv_map.keys():
-                final_result[key] = df[key].values
-
-        return final_result
 
     def opsim2df(self, filename: str) -> pd.DataFrame:
         """Read an opsim database and return a pandas data frame.
@@ -205,7 +79,7 @@ def make_fbs_observation_from_target(target: DriverTarget) -> np.ndarray:
     `np.ndarray`
         Feature based scheduler observation.
     """
-    observation = empty_observation()
+    observation = rs_sched_utils.empty_observation()
 
     observation["ID"][0] = target.targetid
     observation["filter"][0] = target.filter

--- a/python/lsst/ts/scheduler/utils/test/feature_scheduler_sim.py
+++ b/python/lsst/ts/scheduler/utils/test/feature_scheduler_sim.py
@@ -206,9 +206,9 @@ class FeatureSchedulerSim:
         observation_database_name : `str`, optional
             Name ot the observation database.
         """
-        self.config.feature_scheduler_driver_configuration[
-            "scheduler_config"
-        ] = test_config_dir.parents[1].joinpath("data", "config", scheduler_config_name)
+        self.config.feature_scheduler_driver_configuration["scheduler_config"] = (
+            test_config_dir.parents[1].joinpath("data", "config", scheduler_config_name)
+        )
 
         if observation_database_name is not None:
             self.config.feature_scheduler_driver_configuration[

--- a/python/lsst/ts/scheduler/utils/test/feature_scheduler_sim.py
+++ b/python/lsst/ts/scheduler/utils/test/feature_scheduler_sim.py
@@ -30,13 +30,14 @@ from lsst.ts import observing
 from lsst.ts.astrosky.model import AstronomicalSkyModel
 from lsst.ts.dateloc import ObservatoryLocation
 from lsst.ts.observatory.model import ObservatoryModel, ObservatoryState
-from rubin_sim.site_models.cloud_model import CloudModel
-from rubin_sim.site_models.seeing_model import SeeingModel
+from rubin_scheduler.site_models.cloud_model import CloudModel
+from rubin_scheduler.site_models.seeing_model import SeeingModel
+from rubin_scheduler.utils import survey_start_mjd
 
 from ...driver import FeatureScheduler
 from ...driver.feature_scheduler_target import FeatureSchedulerTarget
 
-MJD_START = 60110.983
+MJD_START = survey_start_mjd()
 
 
 class FeatureSchedulerSim:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ import pytest
 import requests
 from lsst.ts import utils
 from lsst.ts.scheduler.utils.csc_utils import DDS_VERSION
-from rubin_sim.data.data_sets import get_data_dir
-from rubin_sim.data.rs_download_sky import MyHTMLParser
+from rubin_scheduler.data.data_sets import get_data_dir
+from rubin_scheduler.data.rs_download_sky import MyHTMLParser
 
 
 def has_required_sky_file(path: pathlib.Path, mjd: float) -> bool:
@@ -128,7 +128,7 @@ def find_sky_file(source: str, mjd: float) -> str:
 
 def download_sky_file(path: pathlib.Path, mjd: float) -> None:
     """Download sky file for the specified mjd into the provided path from the
-    rubin_sim server.
+    rubin_sim_data server.
 
     Parameters
     ----------
@@ -137,7 +137,8 @@ def download_sky_file(path: pathlib.Path, mjd: float) -> None:
     mjd : `float`
         MJD of the test.
     """
-    source = "https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sims_skybrightness_pre/h5/"
+    source = "https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/"
+    source += "sims_skybrightness_pre/h5_2023_09_12/"
 
     if not path.exists():
         path.mkdir(parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import numpy as np
 import pytest
 import requests
 from lsst.ts import utils
+from lsst.ts.scheduler.utils import efd_utils
 from lsst.ts.scheduler.utils.csc_utils import DDS_VERSION
 from rubin_scheduler.data.data_sets import get_data_dir
 from rubin_scheduler.data.rs_download_sky import MyHTMLParser
@@ -204,3 +205,8 @@ def start_ospl_daemon() -> None:
         print(f"ospl status {output.returncode}... Nothing to do.")
 
         yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_efd_client() -> None:
+    efd_utils.__with_lsst_efd_client__ = False

--- a/tests/data/config/fbs_config_anytime_targets.py
+++ b/tests/data/config/fbs_config_anytime_targets.py
@@ -1,11 +1,11 @@
 import numpy as np
-import rubin_sim.scheduler.basis_functions as bf
-import rubin_sim.scheduler.detailers as detailers
+import rubin_scheduler.scheduler.basis_functions as bf
+import rubin_scheduler.scheduler.detailers as detailers
 from lsst.ts.scheduler.utils.test.feature_scheduler_sim import MJD_START
-from rubin_sim.scheduler.model_observatory import ModelObservatory
-from rubin_sim.scheduler.schedulers import CoreScheduler
-from rubin_sim.scheduler.surveys import GreedySurvey
-from rubin_sim.scheduler.utils import Footprint, standard_goals
+from rubin_scheduler.scheduler.model_observatory import ModelObservatory
+from rubin_scheduler.scheduler.schedulers import CoreScheduler
+from rubin_scheduler.scheduler.surveys import GreedySurvey
+from rubin_scheduler.scheduler.utils import Footprint, SkyAreaGenerator
 
 
 def gen_greedy_surveys(
@@ -132,7 +132,8 @@ if __name__ == "config":
     observatory.sky_model.load_length = 3
     conditions = observatory.return_conditions()
 
-    footprints_hp = standard_goals(nside=nside)
+    sky = SkyAreaGenerator(nside=nside)
+    footprints_hp, footprints_labels = sky.return_maps()
 
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside

--- a/tests/data/config/fbs_config_anytime_targets.py
+++ b/tests/data/config/fbs_config_anytime_targets.py
@@ -138,7 +138,7 @@ if __name__ == "config":
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside
     )
-    for i, key in enumerate(footprints_hp):
+    for i, key in enumerate(footprints_hp.dtype.names):
         footprints.footprints[i, :] = footprints_hp[key]
 
     greedy = gen_greedy_surveys(nside, nexp=1, footprints=footprints, seed=seed)

--- a/tests/data/config/fbs_config_good.py
+++ b/tests/data/config/fbs_config_good.py
@@ -1,11 +1,11 @@
 import numpy as np
-import rubin_sim.scheduler.basis_functions as bf
-import rubin_sim.scheduler.detailers as detailers
+import rubin_scheduler.scheduler.basis_functions as bf
+import rubin_scheduler.scheduler.detailers as detailers
 from lsst.ts.scheduler.utils.test.feature_scheduler_sim import MJD_START
-from rubin_sim.scheduler.model_observatory import ModelObservatory
-from rubin_sim.scheduler.schedulers import CoreScheduler
-from rubin_sim.scheduler.surveys import GreedySurvey
-from rubin_sim.scheduler.utils import Footprint, standard_goals
+from rubin_scheduler.scheduler.model_observatory import ModelObservatory
+from rubin_scheduler.scheduler.schedulers import CoreScheduler
+from rubin_scheduler.scheduler.surveys import GreedySurvey
+from rubin_scheduler.scheduler.utils import Footprint, SkyAreaGenerator
 
 
 def gen_greedy_surveys(
@@ -28,9 +28,9 @@ def gen_greedy_surveys(
     """
     Make a quick set of greedy surveys
 
-    This is a convienence function to generate a list of survey objects that
-    can be used with lsst.sims.featureScheduler.schedulers.CoreScheduler.
-    To ensure we are robust against changes in the sims_featureScheduler
+    This is a convenience function to generate a list of survey objects that
+    can be used with rubin_scheduler.schedulers.CoreScheduler.
+    To ensure we are robust against changes in the rubin_scheduler
     codebase, all kwargs are explicitly set.
 
     Parameters
@@ -48,7 +48,7 @@ def gen_greedy_surveys(
     shadow_minutes : float (60.)
         Used to mask regions around zenith (minutes).
     max_alt : float (76.)
-        The maximium altitude to use when masking zenith (degrees).
+        The maximum altitude to use when masking zenith (degrees).
     moon_distance : float (30.)
         The mask radius to apply around the moon (degrees).
     ignore_obs : str or list of str ('DD')
@@ -154,7 +154,8 @@ if __name__ == "config":
     observatory.sky_model.load_length = 3
     conditions = observatory.return_conditions()
 
-    footprints_hp = standard_goals(nside=nside)
+    sky = SkyAreaGenerator(nside=nside)
+    footprints_hp, labels = sky.return_maps()
 
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside

--- a/tests/data/config/fbs_config_good.py
+++ b/tests/data/config/fbs_config_good.py
@@ -71,7 +71,7 @@ def gen_greedy_surveys(
         "smoothing_kernel": None,
         "seed": seed,
         "camera": "LSST",
-        "dither": True,
+        "dither": False,
         "survey_name": "greedy",
     }
 
@@ -160,7 +160,7 @@ if __name__ == "config":
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside
     )
-    for i, key in enumerate(footprints_hp):
+    for i, key in enumerate(footprints_hp.dtype.names):
         footprints.footprints[i, :] = footprints_hp[key]
 
     greedy = gen_greedy_surveys(nside, nexp=1, footprints=footprints, seed=seed)

--- a/tests/data/config/fbs_config_good_with_cwfs.py
+++ b/tests/data/config/fbs_config_good_with_cwfs.py
@@ -1,11 +1,11 @@
 import numpy as np
-import rubin_sim.scheduler.basis_functions as bf
-import rubin_sim.scheduler.detailers as detailers
+import rubin_scheduler.scheduler.basis_functions as bf
+import rubin_scheduler.scheduler.detailers as detailers
 from lsst.ts.scheduler.utils.test.feature_scheduler_sim import MJD_START
-from rubin_sim.scheduler.model_observatory import ModelObservatory
-from rubin_sim.scheduler.schedulers import CoreScheduler
-from rubin_sim.scheduler.surveys import GreedySurvey
-from rubin_sim.scheduler.utils import Footprint, standard_goals
+from rubin_scheduler.scheduler.model_observatory import ModelObservatory
+from rubin_scheduler.scheduler.schedulers import CoreScheduler
+from rubin_scheduler.scheduler.surveys import GreedySurvey
+from rubin_scheduler.scheduler.utils import Footprint, SkyAreaGenerator
 
 
 def gen_cwfs_survey(nside, survey_name, time_gap_min):
@@ -163,7 +163,8 @@ if __name__ == "config":
     observatory.sky_model.load_length = 3
     conditions = observatory.return_conditions()
 
-    footprints_hp = standard_goals(nside=nside)
+    sky = SkyAreaGenerator(nside=nside)
+    footprints_hp, labels = sky.return_maps()
 
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside

--- a/tests/data/config/fbs_config_good_with_cwfs.py
+++ b/tests/data/config/fbs_config_good_with_cwfs.py
@@ -169,7 +169,7 @@ if __name__ == "config":
     footprints = Footprint(
         conditions.mjd_start, sun_ra_start=conditions.sun_ra_start, nside=nside
     )
-    for i, key in enumerate(footprints_hp):
+    for i, key in enumerate(footprints_hp.dtype.names):
         footprints.footprints[i, :] = footprints_hp[key]
 
     greedy = gen_greedy_surveys(nside, nexp=1, footprints=footprints, seed=seed)

--- a/tests/test_fbs_driver.py
+++ b/tests/test_fbs_driver.py
@@ -63,9 +63,9 @@ class TestFeatureSchedulerDriver(unittest.TestCase):
         return self.feature_scheduler_sim.config
 
     def test_configure_scheduler(self):
-        self.config.feature_scheduler_driver_configuration[
-            "scheduler_config"
-        ] = "no_file.py"
+        self.config.feature_scheduler_driver_configuration["scheduler_config"] = (
+            "no_file.py"
+        )
 
         with self.assertRaises(RuntimeError):
             survey_topology = self.driver.configure_scheduler(self.config)

--- a/tests/test_fbs_target.py
+++ b/tests/test_fbs_target.py
@@ -31,7 +31,7 @@ from lsst.ts import observing
 from lsst.ts.observatory.model import ObservatoryModel
 from lsst.ts.scheduler.driver.feature_scheduler_target import FeatureSchedulerTarget
 from lsst.ts.scheduler.utils.test.feature_scheduler_sim import MJD_START
-from rubin_sim.scheduler.utils import empty_observation
+from rubin_scheduler.scheduler.utils import empty_observation
 
 
 class TestFeatureSchedulerTarget(unittest.TestCase):

--- a/tests/test_sequential_driver.py
+++ b/tests/test_sequential_driver.py
@@ -30,8 +30,8 @@ from lsst.ts.observatory.model import ObservatoryModel, ObservatoryState
 from lsst.ts.scheduler.driver import SequentialScheduler, SurveyTopology
 from lsst.ts.scheduler.utils.test import FeatureSchedulerSim
 from lsst.ts.utils import current_tai
-from rubin_sim.site_models.cloud_model import CloudModel
-from rubin_sim.site_models.seeing_model import SeeingModel
+from rubin_scheduler.site_models.cloud_model import CloudModel
+from rubin_scheduler.site_models.seeing_model import SeeingModel
 
 
 class TestSequentialScheduler(unittest.TestCase):


### PR DESCRIPTION
Replace rubin_sim imports with rubin_scheduler imports.
I also synced MJD_START up with the expected "survey_start_date()" function from rubin_scheduler; the small skybrightness pre-calculated files should match this start date. 
I also updated the use of standard_goals (which is deprecated) to SkyAreaGenerator .. the footprint in use  in the test should be approximately the same, but we have moved to this class to make it easier to subclass as we move through iterations of the footprint. 
If you ever want a larger example scheduler setup, we do now have a standard baseline setup in "rubin_scheduler.scheduler.example_scheduler", that we expect to update as the standard baseline design changes (this is also more complicated than the scheduler setup currently being used in the tests, so may not be useful). 
I pointed the skybrightness_pre download to the newer location of our data files. It looks like maybe we should adopt some of the functions in conftest.py to load skybrightness files for a particular date though, then they would be available to a wider audience for simulations too (and you wouldn't have to worry about the URL being outdated if we update the skybrightness files). 